### PR TITLE
Add an option to hide the filename in the record tab

### DIFF
--- a/src/GUI/PageOutput.cpp
+++ b/src/GUI/PageOutput.cpp
@@ -160,6 +160,11 @@ PageOutput::PageOutput(MainWindow* main_window)
 		m_lineedit_file = new QLineEdit(groupbox_file);
 		m_lineedit_file->setToolTip("The recording will be saved to this location.");
 		QPushButton *button_browse = new QPushButton("Browse...", groupbox_file);
+		QLabel *label_hide = new QLabel("Hide filename:", groupbox_file);
+		m_checkbox_hide = new QCheckBox(groupbox_file);
+		m_checkbox_hide->setToolTip("On streaming sites like twitch.tv the filename is the private key.\n"
+								    "With this option the filename is hidden on the next tab.\n"
+								    "This prevents the key from being shown in a stream by accident.");
 
 		connect(m_combobox_container, SIGNAL(activated(int)), this, SLOT(UpdateContainerFields()));
 		connect(m_combobox_container_av, SIGNAL(activated(int)), this, SLOT(UpdateContainerFields()));
@@ -173,6 +178,8 @@ PageOutput::PageOutput(MainWindow* main_window)
 		layout->addWidget(label_file, 2, 0);
 		layout->addWidget(m_lineedit_file, 2, 1);
 		layout->addWidget(button_browse, 2, 2);
+		layout->addWidget(label_hide, 3, 0);
+		layout->addWidget(m_checkbox_hide, 3, 1, 1, 2);
 	}
 	QGroupBox *groupbox_video = new QGroupBox("Video", this);
 	{
@@ -347,6 +354,7 @@ void PageOutput::LoadSettings(QSettings* settings) {
 	SetContainer((enum_container) settings->value("output/container", default_container).toUInt());
 	SetContainerAV(settings->value("output/container_av", default_container).toUInt());
 	SetFile(settings->value("output/file", "").toString());
+	SetHideFilename(settings->value("output/hidefilename", false).toBool());
 	SetVideoCodec((enum_video_codec) settings->value("output/video/codec", default_video_codec).toUInt());
 	SetVideoCodecAV(settings->value("output/video/codec_av", default_video_codec).toUInt());
 	SetVideoKBitRate(settings->value("output/video/kbit_rate", 5000).toUInt());
@@ -370,6 +378,7 @@ void PageOutput::SaveSettings(QSettings* settings) {
 	settings->setValue("output/container", GetContainer());
 	settings->setValue("output/container_av", GetContainerAV());
 	settings->setValue("output/file", GetFile());
+	settings->setValue("output/hidefilename", GetHideFilename());
 	settings->setValue("output/video/codec", GetVideoCodec());
 	settings->setValue("output/video/codec_av", GetVideoCodecAV());
 	settings->setValue("output/video/kbit_rate", GetVideoKBitRate());

--- a/src/GUI/PageOutput.h
+++ b/src/GUI/PageOutput.h
@@ -91,6 +91,7 @@ private:
 	QLabel *m_label_container_av;
 	QComboBox *m_combobox_container_av;
 	QLineEdit *m_lineedit_file;
+	QCheckBox *m_checkbox_hide;
 	QComboBox *m_combobox_video_codec;
 	QLabel *m_label_video_codec_av;
 	QComboBox *m_combobox_video_codec_av;
@@ -128,6 +129,7 @@ public:
 	inline enum_container GetContainer() { return (enum_container) clamp(0, CONTAINER_COUNT - 1, m_combobox_container->currentIndex()); }
 	inline unsigned int GetContainerAV() { return clamp<unsigned int>(0, m_containers_av.size() - 1, m_combobox_container_av->currentIndex()); }
 	inline QString GetFile() { return m_lineedit_file->text(); }
+	inline bool GetHideFilename() { return m_checkbox_hide->isChecked(); }
 	inline enum_video_codec GetVideoCodec() { return (enum_video_codec) clamp(0, VIDEO_CODEC_COUNT - 1, m_combobox_video_codec->currentIndex()); }
 	inline unsigned int GetVideoCodecAV() { return clamp<unsigned int>(0, m_video_codecs_av.size() - 1, m_combobox_video_codec_av->currentIndex()); }
 	inline unsigned int GetVideoKBitRate() { return m_lineedit_video_kbit_rate->text().toUInt(); }
@@ -143,6 +145,7 @@ public:
 	inline void SetContainer(enum_container container) { m_combobox_container->setCurrentIndex(clamp<unsigned int>(0, CONTAINER_COUNT - 1, container)); }
 	inline void SetContainerAV(unsigned int container) { m_combobox_container_av->setCurrentIndex(clamp<unsigned int>(0, m_containers_av.size() - 1, container)); }
 	inline void SetFile(const QString& file) { m_lineedit_file->setText(file); }
+	inline void SetHideFilename(bool show) { m_checkbox_hide->setChecked(show); }
 	inline void SetVideoCodec(enum_video_codec video_codec) { m_combobox_video_codec->setCurrentIndex(clamp<unsigned int>(0, VIDEO_CODEC_COUNT - 1, video_codec)); }
 	inline void SetVideoCodecAV(unsigned int video_codec) { m_combobox_video_codec_av->setCurrentIndex(clamp<unsigned int>(0, m_video_codecs_av.size() - 1, video_codec)); }
 	inline void SetVideoKBitRate(unsigned int kbit_rate) { m_lineedit_video_kbit_rate->setText(QString::number(kbit_rate)); }

--- a/src/GUI/PageRecord.cpp
+++ b/src/GUI/PageRecord.cpp
@@ -340,6 +340,7 @@ void PageRecord::PageStart() {
 	m_glinject_insert_duplicates = page_input->GetGLInjectInsertDuplicates();
 
 	// get the output settings
+	m_hide_filename = page_output->GetHideFilename();
 	m_file = page_output->GetFile();
 	m_video_out_width = 0;
 	m_video_out_height = 0;
@@ -748,7 +749,8 @@ void PageRecord::UpdateInformation() {
 			m_label_video_out_size->setText("?");
 		else
 			m_label_video_out_size->setText(QString::number(m_video_out_width) + "x" + QString::number(m_video_out_height));
-		m_label_file_name->setText(QFileInfo(m_file).fileName());
+		QString sFilename = (m_hide_filename) ? "*****" : m_file;
+		m_label_file_name->setText(QFileInfo(sFilename).fileName());
 		m_label_file_size->setText(ReadableSize(current_bytes, "B"));
 		m_label_file_bit_rate->setText(ReadableSize((uint64_t) (bit_rate + 0.5), "bps"));
 

--- a/src/GUI/PageRecord.h
+++ b/src/GUI/PageRecord.h
@@ -44,6 +44,7 @@ private:
 
 	bool m_page_started, m_encoders_started, m_capturing, m_previewing;
 	bool m_video_record_cursor, m_video_follow_cursor, m_video_glinject;
+	bool m_hide_filename;
 	unsigned int m_video_x, m_video_y, m_video_in_width, m_video_in_height;
 	bool m_video_scaling;
 	unsigned int m_video_scaled_width, m_video_scaled_height;


### PR DESCRIPTION
On streaming sites like twitch.tv the filename is the private key.
With this option the filename is hidden on the next tab.
This prevents the key from being shown in a stream by accident.
