### PR TITLE
[probably bugfix?] Compiler complains about MMX

### DIFF
--- a/src/AV/FastScaler_Convert.cpp
+++ b/src/AV/FastScaler_Convert.cpp
@@ -22,6 +22,9 @@ along with SimpleScreenRecorder.  If not, see <http://www.gnu.org/licenses/>.
 
 #if SSR_USE_X86_ASM
 
+#ifndef __MMX__
+#define __MMX__
+#endif
 #ifndef __SSE__
 #define __SSE__
 #endif

--- a/src/AV/FastScaler_Scale.cpp
+++ b/src/AV/FastScaler_Scale.cpp
@@ -25,13 +25,16 @@ along with SimpleScreenRecorder.  If not, see <http://www.gnu.org/licenses/>.
 #if SSR_USE_X86_ASM
 
 void MipMap_BGRA_SSSE3_Dynamic(unsigned int in_w, unsigned int in_h, const uint8_t* in_data, int in_stride,
-							   uint8_t* out_data, int out_stride, unsigned int mx, unsigned int my) __attribute__((__target__("sse,sse2,sse3,ssse3")));
+							   uint8_t* out_data, int out_stride, unsigned int mx, unsigned int my) __attribute__((__target__("mmx,sse,sse2,sse3,ssse3")));
 void MipMap_BGRA_SSSE3(unsigned int in_w, unsigned int in_h, const uint8_t* in_data, int in_stride,
-					   uint8_t* out_data, int out_stride, unsigned int mx, unsigned int my) __attribute__((__target__("sse,sse2,sse3,ssse3")));
+					   uint8_t* out_data, int out_stride, unsigned int mx, unsigned int my) __attribute__((__target__("mmx,sse,sse2,sse3,ssse3")));
 void Bilinear_BGRA_SSSE3(unsigned int in_w, unsigned int in_h, const uint8_t* in_data, int in_stride,
 						 unsigned int out_w, unsigned int out_h, uint8_t* out_data, int out_stride,
-						 unsigned int mx, unsigned int my) __attribute__((__target__("sse,sse2,sse3,ssse3")));
+						 unsigned int mx, unsigned int my) __attribute__((__target__("mmx,sse,sse2,sse3,ssse3")));
 
+#ifndef __MMX__
+#define __MMX__
+#endif
 #ifndef __SSE__
 #define __SSE__
 #endif


### PR DESCRIPTION
Noticed that couldn't compile SSR because of some bug related to
xmmintrin.h, mmmintrin.h and tmmintrin.h files. After looking at the
code, noticed that an #error was being triggered because some **MMX**
constant wasn't defined.

Found that both AV/FastScaler_Convert.cpp and AV/FastScaler_Scale.cpp
defined constants related to CPU features such as SSE or SSE2, but
not MMX, which is another CPU feature, so I defined **MMX** too.

I don't know if leaving out **MMX** was intentional or not or even
if adding **MMX** is completely unrelated to the code but it seems
to work as now it compiles again. I've tested it by doing some test
recordings and I don't seem to receive any errors so I suppose it's a
bugfix.
