### PR TITLE
Bump Ubuntu version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ For Ubuntu 12.04 - 13.04:
     libavcodec-dev libavutil-dev libswscale-dev libasound2-dev libpulse-dev libjack-jackd2-dev \
     libgl1-mesa-dev libglu1-mesa-dev libx11-dev libxfixes-dev libxext-dev libxi-dev g++-multilib ia32-libs
 
-For Ubuntu 13.10:
+For Ubuntu 13.10 - 14.04:
 
     sudo apt-get install build-essential pkg-config qt4-qmake libqt4-dev libavformat-dev \
     libavcodec-dev libavutil-dev libswscale-dev libasound2-dev libpulse-dev libjack-jackd2-dev \


### PR DESCRIPTION
Verified this apt command still works under Ubuntu 14.04 32-bit. Program compiles successfully. Haven't tested 64-bit version, though, so I cannot talk about `libx11-6:i386` `libxfixes3:i386` and `libglu1-mesa:i386`. Yet Ubuntu Package database reports these packages haven't received any upgrades between 13.10 and 14.04 so I wouldn't expect a fail.
- [libx11-6: 2:1.6.1-1ubuntu1 (13.10) -> 2:1.6.2-1ubuntu2 (14.04)](http://packages.ubuntu.com/search?keywords=libx11-6)
- [libxfixes3: 1:5.0.1-1ubuntu1 (13.10) -> 1:5.0.1-1ubuntu1 (14.04)](http://packages.ubuntu.com/search?keywords=libxfixes3)
- [libglu1-mesa: 9.0.0-1 (13.10) -> 9.0.0-2 (14.04)](http://packages.ubuntu.com/search?keywords=libglu1-mesa)
