### PR TITLE
ignoring compiled binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ build/
 build32/
 
 private-*
+src/simplescreenrecorder


### PR DESCRIPTION
Just compiled from source by configure && make I've noticed that fresh binary is not ignored. Supposedly fixed.
