### PR TITLE
Include QDialogButtonBox header to ensure Dialogs builds with Qt5

### DIFF
--- a/src/Global.h
+++ b/src/Global.h
@@ -32,6 +32,7 @@ along with SimpleScreenRecorder.  If not, see <http://www.gnu.org/licenses/>.
 #include <QAction>
 #include <QApplication>
 #include <QDesktopWidget>
+#include <QDialogButtonBox>
 #include <QFileDialog>
 #include <QInputDialog>
 #include <QMainWindow>


### PR DESCRIPTION
Fixes following build error with Qt 5.4.0:

```
../../src/common/Dialogs.cpp: In function ‘enum_button MessageBox(QMessageBox::Icon, QWidget*, const QString&, const QString&, int, enum_button)’:
../../src/common/Dialogs.cpp:35:23: error: ‘QDialogButtonBox’ has not been declared
   {BUTTON_OK        , QDialogButtonBox::tr("&OK")        , QMessageBox::AcceptRole, NULL},
                       ^
../../src/common/Dialogs.cpp:36:23: error: ‘QDialogButtonBox’ has not been declared
   {BUTTON_CANCEL    , QDialogButtonBox::tr("&Cancel")    , QMessageBox::RejectRole, NULL},
                       ^
../../src/common/Dialogs.cpp:37:23: error: ‘QDialogButtonBox’ has not been declared
   {BUTTON_YES       , QDialogButtonBox::tr("&Yes")       , QMessageBox::YesRole   , NULL},
                       ^
../../src/common/Dialogs.cpp:38:23: error: ‘QDialogButtonBox’ has not been declared
   {BUTTON_YES_ALWAYS, QDialogButtonBox::tr("Yes, always"), QMessageBox::YesRole   , NULL},
                       ^
../../src/common/Dialogs.cpp:39:23: error: ‘QDialogButtonBox’ has not been declared
   {BUTTON_NO        , QDialogButtonBox::tr("&No")        , QMessageBox::NoRole    , NULL},
                       ^
../../src/common/Dialogs.cpp:40:23: error: ‘QDialogButtonBox’ has not been declared
   {BUTTON_NO_NEVER  , QDialogButtonBox::tr("No, never")  , QMessageBox::NoRole    , NULL},
                       ^
../../src/common/Dialogs.cpp: In function ‘QString InputBox(QWidget*, const QString&, const QString&, const QString&)’:
../../src/common/Dialogs.cpp:72:25: error: ‘QDialogButtonBox’ has not been declared
  dialog.setOkButtonText(QDialogButtonBox::tr("&OK"));
                         ^
../../src/common/Dialogs.cpp:73:29: error: ‘QDialogButtonBox’ has not been declared
  dialog.setCancelButtonText(QDialogButtonBox::tr("&Cancel"));
```
