### PR TITLE
Simplified UI flow

### DIFF
--- a/src/GUI/MainWindow.cpp
+++ b/src/GUI/MainWindow.cpp
@@ -99,6 +99,7 @@ MainWindow::MainWindow()
 	if(!g_option_start_hidden)
 		show();
 	m_page_record->UpdateShowHide();
+	m_page_record->OnUpdateHotkey();
 
 }
 

--- a/src/GUI/MainWindow.cpp
+++ b/src/GUI/MainWindow.cpp
@@ -133,13 +133,20 @@ void MainWindow::SaveSettings() {
 }
 
 void MainWindow::closeEvent(QCloseEvent* event) {
+	if (g_option_systray) {
+		OnShowHide();
+		event->ignore();
+    	return;
+	}
+
 	if(m_page_record->ShouldBlockClose()) {
 		event->ignore();
 		return;
 	}
-	SaveSettings();
+
 	event->accept();
-	QApplication::quit();
+	Quit();
+
 }
 
 void MainWindow::GoPageWelcome() {
@@ -178,4 +185,9 @@ void MainWindow::OnSysTrayActivated(QSystemTrayIcon::ActivationReason reason) {
 	if(reason == QSystemTrayIcon::Trigger || reason == QSystemTrayIcon::DoubleClick) {
 		OnShowHide();
 	}
+}
+
+void MainWindow::Quit() {
+	SaveSettings();
+	QApplication::quit();
 }

--- a/src/GUI/MainWindow.cpp
+++ b/src/GUI/MainWindow.cpp
@@ -132,6 +132,15 @@ void MainWindow::SaveSettings() {
 
 }
 
+bool MainWindow::Validate() {
+	if(!m_page_output->Validate()) {
+		return false;
+	}
+
+	return true;
+
+}
+
 void MainWindow::closeEvent(QCloseEvent* event) {
 	if (g_option_systray) {
 		OnShowHide();

--- a/src/GUI/MainWindow.h
+++ b/src/GUI/MainWindow.h
@@ -59,6 +59,8 @@ public:
 	void LoadSettings();
 	void SaveSettings();
 
+	bool Validate();
+
 protected:
 	virtual void closeEvent(QCloseEvent* event) override;
 

--- a/src/GUI/MainWindow.h
+++ b/src/GUI/MainWindow.h
@@ -80,4 +80,6 @@ public slots:
 	void OnShowHide();
 	void OnSysTrayActivated(QSystemTrayIcon::ActivationReason reason);
 
+	void Quit();
+
 };

--- a/src/GUI/PageOutput.cpp
+++ b/src/GUI/PageOutput.cpp
@@ -652,17 +652,27 @@ void PageOutput::OnBrowse() {
 }
 
 void PageOutput::OnContinue() {
+	if(!Validate()) {
+		return;
+	}
+
+	m_main_window->GoPageRecord();
+}
+
+bool PageOutput::Validate() {
 	QString file = GetFile();
 	if(file.isEmpty()) {
 		MessageBox(QMessageBox::Critical, this, MainWindow::WINDOW_CAPTION, tr("You did not select an output file!"), BUTTON_OK, BUTTON_OK);
-		return;
+		return false;
 	}
 	if(GetFileProtocol().isNull() && !GetSeparateFiles() && QFileInfo(file).exists()) {
 		if(MessageBox(QMessageBox::Warning, this, MainWindow::WINDOW_CAPTION,
 					  tr("The file '%1' already exists. Are you sure that you want to overwrite it?").arg(QFileInfo(file).fileName()),
 					  BUTTON_YES | BUTTON_NO, BUTTON_YES) != BUTTON_YES) {
-			return;
+			return false;
 		}
 	}
-	m_main_window->GoPageRecord();
+
+	return true;
+
 }

--- a/src/GUI/PageOutput.h
+++ b/src/GUI/PageOutput.h
@@ -149,6 +149,8 @@ public:
 	QString GetVideoCodecAVName();
 	QString GetAudioCodecAVName();
 
+	bool Validate();
+
 private:
 	unsigned int FindContainerAV(const QString& name);
 	unsigned int FindVideoCodecAV(const QString& name);

--- a/src/GUI/PageRecord.cpp
+++ b/src/GUI/PageRecord.cpp
@@ -967,8 +967,12 @@ void PageRecord::OnRecordStartPause() {
 	if(m_output_started) {
 		StopOutput(false);
 	} else {
-		if(!m_page_started)
+		if(!m_page_started) {
+			if(!m_main_window->Validate()) {
+				return;
+			}
 			m_main_window->GoPageRecord();
+		}
 		StartOutput();
 	}
 }

--- a/src/GUI/PageRecord.cpp
+++ b/src/GUI/PageRecord.cpp
@@ -322,7 +322,7 @@ PageRecord::PageRecord(MainWindow* main_window)
 		menu->addSeparator();
 		m_systray_action_show_hide = menu->addAction(QString(), m_main_window, SLOT(OnShowHide()));
 		m_systray_action_show_hide->setIconVisibleInMenu(true);
-		m_systray_action_quit = menu->addAction(g_icon_quit, tr("Quit"), m_main_window, SLOT(close()));
+		m_systray_action_quit = menu->addAction(g_icon_quit, tr("Quit"), m_main_window, SLOT(Quit()));
 		m_systray_action_quit->setIconVisibleInMenu(true);
 		m_systray_icon->setContextMenu(menu);
 	} else {
@@ -968,7 +968,7 @@ void PageRecord::OnRecordStartPause() {
 		StopOutput(false);
 	} else {
 		if(!m_page_started)
-			StartPage();
+			m_main_window->GoPageRecord();
 		StartOutput();
 	}
 }

--- a/src/GUI/PageRecord.cpp
+++ b/src/GUI/PageRecord.cpp
@@ -894,7 +894,8 @@ void PageRecord::UpdateInput() {
 void PageRecord::UpdateSysTray() {
 	if(m_systray_icon == NULL)
 		return;
-	GroupEnabled({m_systray_action_start_pause, m_systray_action_cancel, m_systray_action_save}, m_page_started);
+	GroupEnabled({m_systray_action_start_pause}, true);
+	GroupEnabled({m_systray_action_cancel, m_systray_action_save}, m_page_started);
 	if(m_page_started && m_output_started) {
 		m_systray_icon->setIcon(g_icon_ssr_recording);
 		m_systray_action_start_pause->setIcon(g_icon_pause);
@@ -961,13 +962,13 @@ void PageRecord::OnUpdateSoundNotifications() {
 }
 
 void PageRecord::OnRecordStartPause() {
-	if(!m_page_started)
-		return;
 	if(m_wait_saving)
 		return;
 	if(m_output_started) {
 		StopOutput(false);
 	} else {
+		if(!m_page_started)
+			StartPage();
 		StartOutput();
 	}
 }

--- a/src/GUI/PageRecord.cpp
+++ b/src/GUI/PageRecord.cpp
@@ -935,7 +935,7 @@ void PageRecord::OnUpdateHotkeyFields() {
 }
 
 void PageRecord::OnUpdateHotkey() {
-	if(m_page_started && IsHotkeyEnabled()) {
+	if(IsHotkeyEnabled()) {
 		unsigned int modifiers = 0;
 		if(IsHotkeyCtrlEnabled()) modifiers |= ControlMask;
 		if(IsHotkeyShiftEnabled()) modifiers |= ShiftMask;

--- a/src/GUI/PageRecord.cpp
+++ b/src/GUI/PageRecord.cpp
@@ -332,7 +332,7 @@ PageRecord::PageRecord(MainWindow* main_window)
 	connect(button_cancel, SIGNAL(clicked()), this, SLOT(OnCancel()));
 	connect(button_save, SIGNAL(clicked()), this, SLOT(OnSave()));
 	if(m_systray_icon != NULL)
-		connect(m_systray_icon, SIGNAL(activated(QSystemTrayIcon::ActivationReason)), m_main_window, SLOT(OnSysTrayActivated(QSystemTrayIcon::ActivationReason)));
+		connect(m_systray_icon, SIGNAL(activated(QSystemTrayIcon::ActivationReason)), this, SLOT(OnSysTrayActivated(QSystemTrayIcon::ActivationReason)));
 
 	QVBoxLayout *layout = new QVBoxLayout(this);
 	layout->addWidget(groupbox_recording);
@@ -1130,4 +1130,10 @@ void PageRecord::OnNewLogLine(Logger::enum_type type, QString string) {
 	if(should_scroll)
 		m_textedit_log->verticalScrollBar()->setValue(m_textedit_log->verticalScrollBar()->maximum());
 
+}
+
+void PageRecord::OnSysTrayActivated(QSystemTrayIcon::ActivationReason reason) {
+	if(reason == QSystemTrayIcon::Trigger || reason == QSystemTrayIcon::DoubleClick) {
+		this->OnRecordStartPause();
+	}
 }

--- a/src/GUI/PageRecord.h
+++ b/src/GUI/PageRecord.h
@@ -181,5 +181,6 @@ private slots:
 
 	void OnUpdateInformation();
 	void OnNewLogLine(Logger::enum_type type, QString string);
+	void OnSysTrayActivated(QSystemTrayIcon::ActivationReason);
 
 };


### PR DESCRIPTION
Hi Maarten,

I've streamlined the UI flow when the settings are already defined:
- Hotkey is always registered and allows to start recording immediately
- Systray click starts recording 
- 'Start recording' in tray context is always enabled
- Closing window minimizes to tray, if tray is present
- Settings are validated before recording starts

This allows to start SSR as systray resident with --start-hidden if recording settings are not changed frequently and makes it really simple to use.

The default flow is unchanged, and --no-systray option allows to start window-only flow (e.g. to record GL applications etc).

--Dmitry
