### PR TITLE
Fixing compilation issues for latest FFMPEG 

### DIFF
--- a/src/AV/AVWrapper.cpp
+++ b/src/AV/AVWrapper.cpp
@@ -93,8 +93,8 @@ bool AVCodecIsInstalled(const QString& codec_name) {
 	return (avcodec_find_encoder_by_name(codec_name.toUtf8().constData()) != NULL);
 }
 
-bool AVCodecSupportsPixelFormat(const AVCodec* codec, PixelFormat pixel_fmt) {
-	const PixelFormat *p = codec->pix_fmts;
+bool AVCodecSupportsPixelFormat(const AVCodec* codec, AVPixelFormat pixel_fmt) {
+	const AVPixelFormat *p = codec->pix_fmts;
 	if(p == NULL)
 		return true; // NULL means 'unknown' or 'any', assume it is supported
 	while(*p != AV_PIX_FMT_NONE) {

--- a/src/AV/AVWrapper.h
+++ b/src/AV/AVWrapper.h
@@ -104,7 +104,7 @@ public:
 
 bool AVFormatIsInstalled(const QString& format_name);
 bool AVCodecIsInstalled(const QString& codec_name);
-bool AVCodecSupportsPixelFormat(const AVCodec* codec, PixelFormat pixel_fmt);
+bool AVCodecSupportsPixelFormat(const AVCodec* codec, AVPixelFormat pixel_fmt);
 bool AVCodecSupportsSampleFormat(const AVCodec* codec, AVSampleFormat sample_fmt);
 
 #if !SSR_USE_AV_CODEC_IS_ENCODER

--- a/src/AV/FastScaler.cpp
+++ b/src/AV/FastScaler.cpp
@@ -46,8 +46,8 @@ FastScaler::~FastScaler() {
 	}
 }
 
-void FastScaler::Scale(unsigned int in_width, unsigned int in_height, PixelFormat in_format, const uint8_t* const* in_data, const int* in_stride,
-					   unsigned int out_width, unsigned int out_height, PixelFormat out_format, uint8_t* const* out_data, const int* out_stride) {
+void FastScaler::Scale(unsigned int in_width, unsigned int in_height, AVPixelFormat in_format, const uint8_t* const* in_data, const int* in_stride,
+					   unsigned int out_width, unsigned int out_height, AVPixelFormat out_format, uint8_t* const* out_data, const int* out_stride) {
 
 	// faster BGRA scaling
 	if(in_format == AV_PIX_FMT_BGRA && out_format == AV_PIX_FMT_BGRA) {

--- a/src/AV/FastScaler.h
+++ b/src/AV/FastScaler.h
@@ -33,8 +33,8 @@ private:
 public:
 	FastScaler();
 	~FastScaler();
-	void Scale(unsigned int in_width, unsigned int in_height, PixelFormat in_format, const uint8_t* const* in_data, const int* in_stride,
-			   unsigned int out_width, unsigned int out_height, PixelFormat out_format, uint8_t* const* out_data, const int* out_stride);
+	void Scale(unsigned int in_width, unsigned int in_height, AVPixelFormat in_format, const uint8_t* const* in_data, const int* in_stride,
+			   unsigned int out_width, unsigned int out_height, AVPixelFormat out_format, uint8_t* const* out_data, const int* out_stride);
 
 private:
 	void Convert_BGRA_YUV444(unsigned int width, unsigned int height, const uint8_t* in_data, int in_stride, uint8_t* const out_data[3], const int out_stride[3]);

--- a/src/AV/Input/X11Input.cpp
+++ b/src/AV/Input/X11Input.cpp
@@ -50,7 +50,7 @@ I am doing the recording myself instead of just using x11grab (as I originally p
 */
 
 // Converts a X11 image format to a format that libav/ffmpeg understands.
-static PixelFormat X11ImageGetPixelFormat(XImage* image) {
+static AVPixelFormat X11ImageGetPixelFormat(XImage* image) {
 	switch(image->bits_per_pixel) {
 		case 8: return AV_PIX_FMT_PAL8;
 		case 16: {
@@ -435,7 +435,7 @@ void X11Input::InputThread() {
 			// push the frame
 			uint8_t *image_data = (uint8_t*) m_x11_image->data;
 			int image_stride = m_x11_image->bytes_per_line;
-			PixelFormat x11_image_format = X11ImageGetPixelFormat(m_x11_image);
+			AVPixelFormat x11_image_format = X11ImageGetPixelFormat(m_x11_image);
 			PushVideoFrame(m_width, m_height, image_data, image_stride, x11_image_format, timestamp);
 			last_timestamp = timestamp;
 

--- a/src/AV/Output/Synchronizer.cpp
+++ b/src/AV/Output/Synchronizer.cpp
@@ -60,7 +60,7 @@ const size_t Synchronizer::MAX_AUDIO_SAMPLES_BUFFERED = 1000000;
 // This is needed because some video codecs/players can't handle long delays.
 const int64_t Synchronizer::MAX_FRAME_DELAY = 200000;
 
-static std::unique_ptr<AVFrameWrapper> CreateVideoFrame(unsigned int width, unsigned int height, PixelFormat pixel_format, const std::shared_ptr<AVFrameData>& reuse_data) {
+static std::unique_ptr<AVFrameWrapper> CreateVideoFrame(unsigned int width, unsigned int height, AVPixelFormat pixel_format, const std::shared_ptr<AVFrameData>& reuse_data) {
 
 	// get required planes
 	unsigned int planes = 0;
@@ -320,7 +320,7 @@ int64_t Synchronizer::GetNextVideoTimestamp() {
 	return videolock->m_next_timestamp;
 }
 
-void Synchronizer::ReadVideoFrame(unsigned int width, unsigned int height, const uint8_t* data, int stride, PixelFormat format, int64_t timestamp) {
+void Synchronizer::ReadVideoFrame(unsigned int width, unsigned int height, const uint8_t* data, int stride, AVPixelFormat format, int64_t timestamp) {
 	assert(m_video_encoder != NULL);
 
 	// add new block to sync diagram

--- a/src/AV/Output/Synchronizer.h
+++ b/src/AV/Output/Synchronizer.h
@@ -99,7 +99,7 @@ private:
 
 	unsigned int m_video_width, m_video_height;
 	unsigned int m_video_frame_rate;
-	PixelFormat m_video_pixel_format;
+	AVPixelFormat m_video_pixel_format;
 	int64_t m_video_max_frames_skipped;
 
 	unsigned int m_audio_channels, m_audio_sample_rate;
@@ -145,7 +145,7 @@ public:
 
 public: // internal
 	virtual int64_t GetNextVideoTimestamp() override;
-	virtual void ReadVideoFrame(unsigned int width, unsigned int height, const uint8_t* data, int stride, PixelFormat format, int64_t timestamp) override;
+	virtual void ReadVideoFrame(unsigned int width, unsigned int height, const uint8_t* data, int stride, AVPixelFormat format, int64_t timestamp) override;
 	virtual void ReadVideoPing(int64_t timestamp) override;
 	virtual void ReadAudioSamples(unsigned int channels, unsigned int sample_rate, AVSampleFormat format, unsigned int sample_count, const uint8_t* data, int64_t timestamp) override;
 	virtual void ReadAudioHole() override;

--- a/src/AV/Output/VideoEncoder.cpp
+++ b/src/AV/Output/VideoEncoder.cpp
@@ -57,7 +57,7 @@ VideoEncoder::~VideoEncoder() {
 	StopThread();
 }
 
-PixelFormat VideoEncoder::GetPixelFormat() {
+AVPixelFormat VideoEncoder::GetPixelFormat() {
 	return GetStream()->codec->pix_fmt;
 }
 

--- a/src/AV/Output/VideoEncoder.h
+++ b/src/AV/Output/VideoEncoder.h
@@ -27,7 +27,7 @@ class VideoEncoder : public BaseEncoder {
 private:
 	struct PixelFormatData {
 		QString m_name;
-		PixelFormat m_format;
+		AVPixelFormat m_format;
 		bool m_is_yuv;
 	};
 
@@ -45,7 +45,7 @@ public:
 	~VideoEncoder();
 
 	// Returns the required pixel format.
-	PixelFormat GetPixelFormat();
+	AVPixelFormat GetPixelFormat();
 
 	unsigned int GetWidth();
 	unsigned int GetHeight();

--- a/src/AV/SourceSink.cpp
+++ b/src/AV/SourceSink.cpp
@@ -69,7 +69,7 @@ int64_t VideoSource::CalculateNextVideoTimestamp() {
 	return SINK_TIMESTAMP_NONE;
 }
 
-void VideoSource::PushVideoFrame(unsigned int width, unsigned int height, const uint8_t* data, int stride, PixelFormat format, int64_t timestamp) {
+void VideoSource::PushVideoFrame(unsigned int width, unsigned int height, const uint8_t* data, int stride, AVPixelFormat format, int64_t timestamp) {
 	SharedLock lock(&m_shared_data);
 	for(SinkData &s : lock->m_sinks) {
 		static_cast<VideoSink*>(s.sink)->ReadVideoFrame(width, height, data, stride, format, timestamp);

--- a/src/AV/SourceSink.h
+++ b/src/AV/SourceSink.h
@@ -18,6 +18,8 @@ along with SimpleScreenRecorder.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 #pragma once
+
+#include <libavutil/pixfmt.h>
 #include "Global.h"
 
 #include "MutexDataPair.h"
@@ -70,7 +72,7 @@ class VideoSource : private BaseSource {
 protected:
 	VideoSource() {}
 	int64_t CalculateNextVideoTimestamp();
-	void PushVideoFrame(unsigned int width, unsigned int height, const uint8_t* data, int stride, PixelFormat format, int64_t timestamp);
+	void PushVideoFrame(unsigned int width, unsigned int height, const uint8_t* data, int stride, AVPixelFormat format, int64_t timestamp);
 	void PushVideoPing(int64_t timestamp);
 };
 
@@ -82,7 +84,7 @@ public:
 	inline void ConnectVideoSource(VideoSource* source, int priority = 0) { ConnectBaseSource(source, priority); }
 public:
 	virtual int64_t GetNextVideoTimestamp() { return SINK_TIMESTAMP_NONE; }
-	virtual void ReadVideoFrame(unsigned int width, unsigned int height, const uint8_t* data, int stride, PixelFormat format, int64_t timestamp) = 0;
+	virtual void ReadVideoFrame(unsigned int width, unsigned int height, const uint8_t* data, int stride, AVPixelFormat format, int64_t timestamp) = 0;
 	virtual void ReadVideoPing(int64_t timestamp) {}
 };
 

--- a/src/Benchmark.cpp
+++ b/src/Benchmark.cpp
@@ -168,7 +168,7 @@ void BenchmarkScale(unsigned int in_w, unsigned int in_h, unsigned int out_w, un
 
 }
 
-void BenchmarkConvert(unsigned int w, unsigned int h, PixelFormat in_format, PixelFormat out_format, const QString& in_format_name, const QString& out_format_name, NewImageFunc in_image, NewImageFunc out_image, ConvertFunc fallback
+void BenchmarkConvert(unsigned int w, unsigned int h, AVPixelFormat in_format, AVPixelFormat out_format, const QString& in_format_name, const QString& out_format_name, NewImageFunc in_image, NewImageFunc out_image, ConvertFunc fallback
 #if SSR_USE_X86_ASM
 , ConvertFunc ssse3
 #endif

--- a/src/GUI/VideoPreviewer.cpp
+++ b/src/GUI/VideoPreviewer.cpp
@@ -77,7 +77,7 @@ int64_t VideoPreviewer::GetNextVideoTimestamp() {
 	return lock->m_next_frame_time;
 }
 
-void VideoPreviewer::ReadVideoFrame(unsigned int width, unsigned int height, const uint8_t* data, int stride, PixelFormat format, int64_t timestamp) {
+void VideoPreviewer::ReadVideoFrame(unsigned int width, unsigned int height, const uint8_t* data, int stride, AVPixelFormat format, int64_t timestamp) {
 	Q_UNUSED(timestamp);
 
 	QSize image_size;

--- a/src/GUI/VideoPreviewer.h
+++ b/src/GUI/VideoPreviewer.h
@@ -70,7 +70,7 @@ public:
 
 	// Reads a video frame from the video source.
 	// This function is thread-safe.
-	virtual void ReadVideoFrame(unsigned int width, unsigned int height, const uint8_t* data, int stride, PixelFormat format, int64_t timestamp) override;
+	virtual void ReadVideoFrame(unsigned int width, unsigned int height, const uint8_t* data, int stride, AVPixelFormat format, int64_t timestamp) override;
 
 	virtual QSize sizeHint() const override { return QSize(100, 100); }
 


### PR DESCRIPTION
Replaced some occurences of 'PixelFormat' with 'AVPixelFormat' since ssr couldn't compile with latest FFMPEG from git.