### PR TITLE
Add required packages for Debian64 installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,10 @@ For Debian:
     sudo apt-get install build-essential pkg-config qt4-qmake libqt4-dev libavformat-dev \
     libavcodec-dev libavutil-dev libswscale-dev libasound2-dev libpulse-dev libjack-jackd2-dev \
     libgl1-mesa-dev libglu1-mesa-dev libx11-dev libxfixes-dev libxext-dev libxi-dev g++-multilib \
-    libx11-6 libxext6 libxfixes3 libxfixes3:i386 libglu1-mesa:i386
-    
+    libx11-6 libxext6 libxfixes3 \
+    libglu1-mesa-dev:i386 libx11-dev:i386 libxfixes-dev:i386 libgl1-mesa-dev:i386 \
+    desktop-file-utils
+
     cd /usr/lib/i386-linux-gnu
     sudo ln -s libGL.so.1 libGL.so
     sudo ln -s libGLU.so.1 libGLU.so


### PR DESCRIPTION
For https://github.com/MaartenBaert/ssr.git on Debian-64bit, the following packages are required:

    libglu1-mesa-dev:i386 libxfixes-dev:i386 
      (instead of libglu1-mesa:i386 libxfixes:i386 --- we need the headers)
    libx11-dev:i386 libgl1-mesa-dev:i386

    desktop-file-utils (needed for the post-install script)

I added the required packages to the installation instructions.  No code changes are made to the sources.