### PR TITLE
X11Input: Support Xvnc

### DIFF
--- a/src/AV/Input/X11Input.cpp
+++ b/src/AV/Input/X11Input.cpp
@@ -248,7 +248,8 @@ void X11Input::Init() {
 			Logger::LogError("[X11Input::Init] " + Logger::tr("Error: Can't create shared image!"));
 			throw X11Exception();
 		}
-		m_x11_shm_info.shmid = shmget(IPC_PRIVATE, m_x11_image->bytes_per_line * m_x11_image->height, IPC_CREAT | 0700);
+		// shm permission 0777 are required for Xvnc
+		m_x11_shm_info.shmid = shmget(IPC_PRIVATE, m_x11_image->bytes_per_line * m_x11_image->height, IPC_CREAT | 0777);
 		if(m_x11_shm_info.shmid == -1) {
 			Logger::LogError("[X11Input::Init] " + Logger::tr("Error: Can't get shared memory!"));
 			throw X11Exception();


### PR DESCRIPTION
Xvnc requires extended shared memory permissions.
Allows to capture screen sessions when running under Xvnc.

Tested on SuSe Linux Enterprise 12 Xvnc Server.

Signed-off-by: Patrick Rudolph <siro@das-labor.org>