### PR TITLE
Fix Qt5LinguistTools detection/lrelease binary location, use FeatureSummary

### DIFF
--- a/src/translations/CMakeLists.txt
+++ b/src/translations/CMakeLists.txt
@@ -1,7 +1,8 @@
 # translations for 'simplescreenrecorder' executable
 
 if(WITH_QT5)
-	find_program(LRELEASE NAMES lrelease-qt5 lrelease)
+	find_package(Qt5LinguistTools REQUIRED)
+	set(LRELEASE Qt5::lrelease)
 else()
 	find_program(LRELEASE NAMES lrelease-qt4 lrelease)
 endif()


### PR DESCRIPTION
If Qt4 is default in qtchooser, cmake was picking up the wrong (qt4-based) lrelease binary.