### PR TITLE
Added command line arguments

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -74,6 +74,8 @@ set(sources
 	AV/SimpleSynth.h
 	AV/SourceSink.cpp
 	AV/SourceSink.h
+	common/CommandSettings.cpp
+	common/CommandSettings.h
 	common/CPUFeatures.cpp
 	common/CPUFeatures.h
 	common/Dialogs.cpp
@@ -85,6 +87,8 @@ set(sources
 	common/MutexDataPair.h
 	common/QueueBuffer.h
 	common/TempBuffer.h
+	common/Terminator.cpp
+	common/Terminator.h
 	GUI/AudioPreviewer.cpp
 	GUI/AudioPreviewer.h
 	GUI/DialogGLInject.cpp

--- a/src/GUI/MainWindow.cpp
+++ b/src/GUI/MainWindow.cpp
@@ -20,6 +20,8 @@ along with SimpleScreenRecorder.  If not, see <http://www.gnu.org/licenses/>.
 #include "MainWindow.h"
 
 #include "Main.h"
+#include "CommandSettings.h"
+#include "Terminator.h"
 #include "Icons.h"
 #include "Dialogs.h"
 #include "EnumStrings.h"
@@ -67,8 +69,16 @@ MainWindow::MainWindow()
 
 	if(m_page_welcome->GetSkipPage()) {
 		m_stacked_layout->setCurrentWidget(m_page_input);
+	} else if (CommandSettings::ShouldRecordOnStart()) {
+		m_stacked_layout->setCurrentWidget(m_page_record);
+		m_page_record->StartPage();
+		m_page_record->StartOutput();
 	} else {
 		m_stacked_layout->setCurrentWidget(m_page_welcome);
+	}
+
+	if (CommandSettings::GetTerminationTimer() > 0) {
+		Terminator(CommandSettings::GetTerminationTimer(), m_page_record);
 	}
 
 	// warning for glitch with proprietary NVIDIA drivers
@@ -121,16 +131,24 @@ MainWindow::~MainWindow() {
 }
 
 void MainWindow::LoadSettings() {
-
 	QSettings settings(GetApplicationUserDir() + "/settings.conf", QSettings::IniFormat);
 
 	SetNVidiaDisableFlipping(StringToEnum(settings.value("global/nvidia_disable_flipping", QString()).toString(), NVIDIA_DISABLE_FLIPPING_ASK));
 
 	m_page_welcome->LoadSettings(&settings);
-	m_page_input->LoadSettings(&settings);
-	m_page_output->LoadSettings(&settings);
+	LoadProfileSettings();
 	m_page_record->LoadSettings(&settings);
 
+}
+
+void MainWindow::LoadProfileSettings() {
+	QString inputProfile = CommandSettings::GetInputProfile();
+	QSettings * inputSettings = ProfileBox::GetProfileSettings(inputProfile, "input-profiles");
+	m_page_input->LoadSettings(inputSettings);
+
+	QString outputProfile = CommandSettings::GetOutputProfile();
+	QSettings * outputSettings = ProfileBox::GetProfileSettings(outputProfile, "output-profiles");
+	m_page_output->LoadSettings(outputSettings);
 }
 
 void MainWindow::SaveSettings() {

--- a/src/GUI/MainWindow.cpp
+++ b/src/GUI/MainWindow.cpp
@@ -148,6 +148,7 @@ void MainWindow::LoadProfileSettings() {
 
 	QString outputProfile = CommandSettings::GetOutputProfile();
 	QSettings * outputSettings = ProfileBox::GetProfileSettings(outputProfile, "output-profiles");
+	outputSettings->setValue("output/file", CommandSettings::GetOutputFile());	
 	m_page_output->LoadSettings(outputSettings);
 }
 

--- a/src/GUI/MainWindow.h
+++ b/src/GUI/MainWindow.h
@@ -53,6 +53,8 @@ private:
 	PageRecord *m_page_record;
 	PageDone *m_page_done;
 
+	void LoadProfileSettings();
+
 public:
 	MainWindow();
 	~MainWindow();

--- a/src/GUI/ProfileBox.h
+++ b/src/GUI/ProfileBox.h
@@ -24,6 +24,9 @@ class ProfileBox : public QGroupBox {
 	Q_OBJECT
 
 public:
+	static QSettings * GetProfileSettings(const QString& name, const QString& type);
+
+public:
 	typedef void (*LoadCallback)(QSettings*, void*);
 	typedef void (*SaveCallback)(QSettings*, void*);
 

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -22,6 +22,7 @@ along with SimpleScreenRecorder.  If not, see <http://www.gnu.org/licenses/>.
 #include "Benchmark.h"
 #include "CPUFeatures.h"
 #include "HotkeyListener.h"
+#include "CommandSettings.h"
 #include "Icons.h"
 #include "Logger.h"
 #include "MainWindow.h"
@@ -38,16 +39,21 @@ void PrintOptionHelp() {
 				"Usage: simplescreenrecorder [OPTIONS]\n"
 				"\n"
 				"Options:\n"
-				"  --help              Show this help message.\n"
-				"  --version           Show version information.\n"
-				"  --logfile           Write log to ~/.ssr/log-DATE_TIME.txt instead of stdout.\n"
-				"  --statsfile[=FILE]  Write recording statistics to FILE. If FILE is omitted,\n"
-				"                      /dev/shm/simplescreenrecorder-stats-PID is used. It will\n"
-				"                      be updated continuously and deleted when the recording\n"
-				"                      page is closed.\n"
-				"  --syncdiagram       Show synchronization diagram (for debugging).\n"
-				"  --no-systray        Don't show the system tray icon.\n"
-				"  --start-hidden      Start the application in hidden form.\n"
+				"  --input_profile[=NAME]     Use this input profile.\n"
+				"  --help                     Show this help message.\n"
+				"  --logfile                  Write log to ~/.ssr/log-DATE_TIME.txt instead of stdout.\n"
+				"  --no-systray               Don't show the system tray icon.\n"
+				"  --output_file              Save to this file.\n"
+				"  --record_on_start          Start recording as soon as application starts.\n"
+				"  --statsfile[=FILE]         Write recording statistics to FILE. If FILE is omitted,\n"
+				"                             /dev/shm/simplescreenrecorder-stats-PID is used. It will\n"
+				"                             be updated continuously and deleted when the recording\n"
+				"                             page is closed.\n"
+				"  --syncdiagram              Show synchronization diagram (for debugging).\n"
+				"  --termination_timer[=SEC]  Stop recording in indicated seconds.\n"
+				"  --start-hidden             Start the application in hidden form.\n"
+				"  --version                  Show version information.\n"
+				"  --output_profile[=NAME]     Use this output profile.\n"
 	);
 }
 
@@ -154,6 +160,16 @@ int main(int argc, char* argv[]) {
 			} else if(option == "--benchmark") {
 				NOVALUE
 				g_option_benchmark = true;
+			} else if (option == "--output_file") {
+				CommandSettings::SetOutputFile(value);
+			} else if (option == "--input_profile") {
+				CommandSettings::SetInputProfile(value);
+			} else if (option == "--output_profile") {
+				CommandSettings::SetOutputProfile(value);
+			} else if (option == "--termination_timer") {
+				CommandSettings::SetTerminationTimer(value);
+			} else if (option == "--record_on_start") {
+				CommandSettings::SetRecordOnStart(true);
 			} else {
 				Logger::LogError("[main] " + Logger::tr("Error: Unknown command-line option '%1'!").arg(option));
 				PrintOptionHelp();

--- a/src/SimpleScreenRecorder.pro
+++ b/src/SimpleScreenRecorder.pro
@@ -40,9 +40,11 @@ SOURCES += \
 	AV/FastScaler_Scale_SSSE3.cpp \
 	AV/SimpleSynth.cpp \
 	AV/SourceSink.cpp \
+	common/CommandSettings.cpp \
 	common/CPUFeatures.cpp \
 	common/Dialogs.cpp \
 	common/Logger.cpp \
+	common/Terminator.cpp \
 	GUI/AudioPreviewer.cpp \
 	GUI/DialogGLInject.cpp \
 	GUI/ElidedLabel.cpp \
@@ -89,6 +91,7 @@ HEADERS  += \
 	AV/SampleCast.h \
 	AV/SimpleSynth.h \
 	AV/SourceSink.h \
+	common/CommandSettings.h \
 	common/CPUFeatures.h \
 	common/Dialogs.h \
 	common/EnumStrings.h \
@@ -97,6 +100,7 @@ HEADERS  += \
 	common/MutexDataPair.h \
 	common/QueueBuffer.h \
 	common/TempBuffer.h \
+	common/Terminator.h \
 	GUI/AudioPreviewer.h \
 	GUI/DialogGLInject.h \
 	GUI/ElidedLabel.h \

--- a/src/common/CommandSettings.cpp
+++ b/src/common/CommandSettings.cpp
@@ -1,0 +1,54 @@
+/*
+Copyright (c) 2012-2017 Maarten Baert <maarten-baert@hotmail.com>
+
+This file is part of SimpleScreenRecorder.
+
+SimpleScreenRecorder is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+SimpleScreenRecorder is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with SimpleScreenRecorder.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "CommandSettings.h"
+#include "Logger.h"
+
+QString CommandSettings::output_file = NULL;
+QString CommandSettings::input_profile = NULL;
+QString CommandSettings::output_profile = NULL;
+int CommandSettings::termination_timer = 0;
+bool CommandSettings::record_on_start = false;
+
+QString CommandSettings::GetOutputFile() {return output_file;}
+QString CommandSettings::GetInputProfile() {return input_profile;}
+QString CommandSettings::GetOutputProfile() {return output_profile;}
+int CommandSettings::GetTerminationTimer() {return termination_timer;}
+bool CommandSettings::ShouldRecordOnStart() {return record_on_start;}
+
+void CommandSettings::SetOutputFile(QString _output_file) {
+	output_file = _output_file;
+}
+
+void CommandSettings::SetInputProfile(QString _input_profile) {
+	input_profile = _input_profile;
+}
+
+void CommandSettings::SetOutputProfile(QString _output_profile) {
+	output_profile = _output_profile;
+}
+
+void CommandSettings::SetTerminationTimer(QString _termination_timer) {
+	// TODO: error check
+	termination_timer = _termination_timer.toInt();
+}
+
+void CommandSettings::SetRecordOnStart(bool _record_on_start) {
+	record_on_start = _record_on_start;
+}

--- a/src/common/CommandSettings.h
+++ b/src/common/CommandSettings.h
@@ -1,0 +1,44 @@
+/*
+Copyright (c) 2012-2017 Maarten Baert <maarten-baert@hotmail.com>
+
+This file is part of SimpleScreenRecorder.
+
+SimpleScreenRecorder is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+SimpleScreenRecorder is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with SimpleScreenRecorder.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+#include "Global.h"
+
+class CommandSettings {
+
+private:
+	static QString output_file;
+	static QString input_profile;
+	static QString output_profile;
+	static int termination_timer;
+	static bool record_on_start;
+
+public:
+	static QString GetOutputFile();
+	static QString GetInputProfile();
+	static QString GetOutputProfile();
+	static int GetTerminationTimer();
+	static bool ShouldRecordOnStart();
+
+	static void SetOutputFile(QString _output_file);
+	static void SetInputProfile(QString _input_profile);
+	static void SetOutputProfile(QString _output_profile);
+	static void SetTerminationTimer(QString _termination_timer);
+	static void SetRecordOnStart(bool _record_on_start);
+};

--- a/src/common/Terminator.cpp
+++ b/src/common/Terminator.cpp
@@ -1,0 +1,39 @@
+/*
+Copyright (c) 2012-2017 Maarten Baert <maarten-baert@hotmail.com>
+
+This file is part of SimpleScreenRecorder.
+
+SimpleScreenRecorder is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+SimpleScreenRecorder is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with SimpleScreenRecorder.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <Terminator.h>
+
+Terminator::Terminator(int _seconds, PageRecord * _page_record) {
+  termData = (TermData*)malloc(sizeof(TermData));
+  termData->seconds = _seconds;
+  termData->page_record = _page_record;
+  pthread_t pth;
+  pthread_create(&pth, NULL, Terminate, termData);
+}
+
+void * Terminator::Terminate(void * _termData) {
+    TermData * termData = ((TermData*)_termData);
+    Logger::LogInfo(Logger::tr("This program will exit in %1 seconds").arg(termData->seconds));
+
+    sleep(termData->seconds);
+    termData->page_record->StopPage(true);
+    free(termData);
+    QCoreApplication::exit(0);
+    return NULL;
+}

--- a/src/common/Terminator.h
+++ b/src/common/Terminator.h
@@ -1,0 +1,23 @@
+#include <QObject>
+#include <QTimer>
+#include <QCoreApplication>
+#include <QThread>
+#include <pthread.h>
+#include <PageRecord.h>
+
+class Terminator : public QObject {
+
+  private:
+    struct TermData {
+      int seconds;
+      int minutes;
+      PageRecord * page_record;
+    };
+
+    TermData * termData;
+
+    static void * Terminate(void * _termData);
+
+  public:
+    Terminator(int _seconds, PageRecord * _page_record);
+};


### PR DESCRIPTION
Added the followning command line arguments:

- input_profile
- output_profile
- termination_timer
- output_file
- record_on_start

This allows your application to be started and stopped via the terminal or a script.

I [request](https://github.com/MaartenBaert/ssr/issues/747)ed this feature last week, went ahead and implemented it myself.

Note: for the termination timer i used pthread, I tried to use qthread and my work can be found on branch command_args_qthread I was unable to get it to  work, I am unfamiliar with the qt framework.