### PR TITLE
Add open folder button

### DIFF
--- a/src/GUI/Icons.cpp
+++ b/src/GUI/Icons.cpp
@@ -20,7 +20,7 @@ along with SimpleScreenRecorder.  If not, see <http://www.gnu.org/licenses/>.
 #include "Icons.h"
 
 QIcon g_icon_ssr, g_icon_ssr_idle, g_icon_ssr_error, g_icon_ssr_paused, g_icon_ssr_recording;
-QIcon g_icon_go_home, g_icon_go_previous, g_icon_go_next;
+QIcon g_icon_go_home, g_icon_go_previous, g_icon_go_next, g_icon_document_open;
 QIcon g_icon_pause, g_icon_record;
 QIcon g_icon_cancel, g_icon_save, g_icon_quit;
 QIcon g_icon_microphone;
@@ -41,6 +41,7 @@ void LoadIcons() {
 		g_icon_go_previous = QIcon::fromTheme("go-previous");
 		g_icon_go_next = QIcon::fromTheme("go-next");
 	}
+        g_icon_document_open = QIcon::fromTheme("document-open");
 
 	g_icon_pause = QIcon::fromTheme("media-playback-pause");
 	g_icon_record = QIcon::fromTheme("media-record");

--- a/src/GUI/Icons.cpp
+++ b/src/GUI/Icons.cpp
@@ -41,7 +41,7 @@ void LoadIcons() {
 		g_icon_go_previous = QIcon::fromTheme("go-previous");
 		g_icon_go_next = QIcon::fromTheme("go-next");
 	}
-        g_icon_document_open = QIcon::fromTheme("document-open");
+	g_icon_document_open = QIcon::fromTheme("document-open");
 
 	g_icon_pause = QIcon::fromTheme("media-playback-pause");
 	g_icon_record = QIcon::fromTheme("media-record");

--- a/src/GUI/Icons.h
+++ b/src/GUI/Icons.h
@@ -21,7 +21,7 @@ along with SimpleScreenRecorder.  If not, see <http://www.gnu.org/licenses/>.
 #include "Global.h"
 
 extern QIcon g_icon_ssr, g_icon_ssr_idle, g_icon_ssr_error, g_icon_ssr_paused, g_icon_ssr_recording;
-extern QIcon g_icon_go_home, g_icon_go_previous, g_icon_go_next;
+extern QIcon g_icon_go_home, g_icon_go_previous, g_icon_go_next, g_icon_document_open;
 extern QIcon g_icon_pause, g_icon_record;
 extern QIcon g_icon_cancel, g_icon_save, g_icon_quit;
 extern QIcon g_icon_microphone;

--- a/src/GUI/PageDone.cpp
+++ b/src/GUI/PageDone.cpp
@@ -21,6 +21,9 @@ along with SimpleScreenRecorder.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "Icons.h"
 #include "MainWindow.h"
+#include "PageOutput.h"
+
+#include <QDesktopServices> // to open the folder with the resulting recording
 
 PageDone::PageDone(MainWindow* main_window)
 	: QWidget(main_window->centralWidget()) {
@@ -31,10 +34,10 @@ PageDone::PageDone(MainWindow* main_window)
 									   "make the file smaller (the default settings are optimized for quality and speed, not file size)."), this);
 	label_done->setWordWrap(true);
 
-        QPushButton *button_open_folder = new QPushButton(g_icon_document_open, tr("Open folder"), this);
+	QPushButton *button_open_folder = new QPushButton(g_icon_document_open, tr("Open folder"), this);
+	connect(button_open_folder, SIGNAL(clicked()), this, SLOT(OpenStorageFolder()));
 
 	QPushButton *button_back = new QPushButton(g_icon_go_home, tr("Back to the start screen"), this);
-
 	connect(button_back, SIGNAL(clicked()), m_main_window, SLOT(GoPageWelcome()));
 
 	QVBoxLayout *layout_page = new QVBoxLayout(this);
@@ -43,4 +46,10 @@ PageDone::PageDone(MainWindow* main_window)
 	layout_page->addStretch();
 	layout_page->addWidget(button_back);
 
+}
+
+void PageDone::OpenStorageFolder() {
+    QString save_directory = m_main_window->GetPageOutput()->GetFile();
+    save_directory.chop(save_directory.size() - save_directory.lastIndexOf('/'));
+	QDesktopServices::openUrl(QUrl::fromLocalFile(save_directory));
 }

--- a/src/GUI/PageDone.cpp
+++ b/src/GUI/PageDone.cpp
@@ -30,12 +30,16 @@ PageDone::PageDone(MainWindow* main_window)
 	QLabel *label_done = new QLabel(tr("The recording has been saved. You can edit the video now, or re-encode it with better settings to "
 									   "make the file smaller (the default settings are optimized for quality and speed, not file size)."), this);
 	label_done->setWordWrap(true);
+
+        QPushButton *button_open_folder = new QPushButton(g_icon_document_open, tr("Open folder"), this);
+
 	QPushButton *button_back = new QPushButton(g_icon_go_home, tr("Back to the start screen"), this);
 
 	connect(button_back, SIGNAL(clicked()), m_main_window, SLOT(GoPageWelcome()));
 
 	QVBoxLayout *layout_page = new QVBoxLayout(this);
 	layout_page->addWidget(label_done);
+        layout_page->addWidget(button_open_folder);
 	layout_page->addStretch();
 	layout_page->addWidget(button_back);
 

--- a/src/GUI/PageDone.cpp
+++ b/src/GUI/PageDone.cpp
@@ -49,7 +49,7 @@ PageDone::PageDone(MainWindow* main_window)
 }
 
 void PageDone::OpenStorageFolder() {
-    QString save_directory = m_main_window->GetPageOutput()->GetFile();
-    save_directory.chop(save_directory.size() - save_directory.lastIndexOf('/'));
+	QString save_directory = m_main_window->GetPageOutput()->GetFile();
+	save_directory.chop(save_directory.size() - save_directory.lastIndexOf('/'));
 	QDesktopServices::openUrl(QUrl::fromLocalFile(save_directory));
 }

--- a/src/GUI/PageDone.h
+++ b/src/GUI/PageDone.h
@@ -31,4 +31,7 @@ private:
 public:
 	PageDone(MainWindow* main_window);
 
+public slots:
+	void OpenStorageFolder();
+
 };


### PR DESCRIPTION
Once I'm done with my recording, I find myself opening the file browser and navigating towards my `~/Videos` folder. I had a nice idea to make that a bit easier: Just add a button that opens the correct folder immediately. Building that wasn't too difficult, so I thought I'd polish it up for you to consider including in the main repository.

I think this makes sense for the workflow. This last page gives a sense that the recording is complete, so it would make sense to see the actual recording in your files. This is how it looks. What do you think?

![image](https://user-images.githubusercontent.com/2448634/82076917-cded2b80-96de-11ea-8aed-c72b90624344.png)

In the implementation I took care to:
* Only use functions that are available for both Qt4 and Qt5.
* Use the same code style as the rest of the code, as much as possible.

I've tested this on Ubuntu 20.04 where I've installed Qt5.14, as well as on a virtual machine running Ubuntu 16.04 with Qt4.8. I've tested this with local files as well as on an SFTP server in my network.

Possible problems
----
One thing I'm not sure about is that I've imported `<QDesktopServices>` in PageDone.cpp. Other imports of the Qt libraries are done in Global.h though. If you'd like me to move it, that won't be a problem. However your notes.txt file says that you'd like to keep GUI code separate and this is a better way to achieve that.

I also didn't update the translation files. If I run the update script it changes a lot of line numbers and also adds a few more strings that I didn't add. So I'm figuring that you probably want to run it yourself once you are ready to make a release.