### PR TITLE
Respect skip_page preference when going back after recording

### DIFF
--- a/src/GUI/MainWindow.cpp
+++ b/src/GUI/MainWindow.cpp
@@ -66,11 +66,7 @@ MainWindow::MainWindow()
 
 	LoadSettings();
 
-	if(m_page_welcome->GetSkipPage()) {
-		m_stacked_layout->setCurrentWidget(m_page_input);
-	} else {
-		m_stacked_layout->setCurrentWidget(m_page_welcome);
-	}
+	GoPageStart();
 
 	// warning for non-X11 window systems (e.g. Wayland)
 	if(!IsPlatformX11()) {
@@ -204,6 +200,13 @@ void MainWindow::closeEvent(QCloseEvent* event) {
 	Quit();
 }
 
+void MainWindow::GoPageStart() {
+	if(m_page_welcome->GetSkipPage()) {
+		m_stacked_layout->setCurrentWidget(m_page_input);
+	} else {
+		m_stacked_layout->setCurrentWidget(m_page_welcome);
+	}
+}
 void MainWindow::GoPageWelcome() {
 	m_stacked_layout->setCurrentWidget(m_page_welcome);
 }

--- a/src/GUI/MainWindow.h
+++ b/src/GUI/MainWindow.h
@@ -76,6 +76,7 @@ public:
 	inline void SetNVidiaDisableFlipping(enum_nvidia_disable_flipping flipping) { m_nvidia_disable_flipping = (enum_nvidia_disable_flipping) clamp((unsigned int) flipping, 0u, (unsigned int) NVIDIA_DISABLE_FLIPPING_COUNT - 1); }
 
 public slots:
+	void GoPageStart();
 	void GoPageWelcome();
 	void GoPageInput();
 	void GoPageOutput();

--- a/src/GUI/PageDone.cpp
+++ b/src/GUI/PageDone.cpp
@@ -36,7 +36,7 @@ PageDone::PageDone(MainWindow* main_window)
 	connect(button_open_folder, SIGNAL(clicked()), this, SLOT(OnOpenFolder()));
 
 	QPushButton *button_back = new QPushButton(g_icon_go_home, tr("Back to the start screen"), this);
-	connect(button_back, SIGNAL(clicked()), m_main_window, SLOT(GoPageWelcome()));
+	connect(button_back, SIGNAL(clicked()), m_main_window, SLOT(GoPageStart()));
 
 	QVBoxLayout *layout = new QVBoxLayout(this);
 	layout->addWidget(label_done);


### PR DESCRIPTION
Currently, after finishing a recording and pressing "Back to the start screen" in the final window, you are taken to the Welcome screen, regardless of whether you have checked "Skip this page next time" on that page.

This fixes that and skips the welcome page if you have checked the preference.