### PR TITLE
Save record before exit on SIGTERM/SIGINT signals

### DIFF
--- a/src/GUI/PageRecord.cpp
+++ b/src/GUI/PageRecord.cpp
@@ -761,11 +761,24 @@ void PageRecord::StopPage(bool save) {
 
 }
 
+PageRecord* g_pagerecord_obj;
+void OnExitSignal(int signum) {
+	if(g_pagerecord_obj)
+		g_pagerecord_obj->OnRecordSave(false);
+
+	exit(signum);
+}
+
 void PageRecord::StartOutput() {
 	assert(m_page_started);
 
 	if(m_output_started)
 		return;
+
+	// register exit signals handlers
+	g_pagerecord_obj = this;
+	signal(SIGTERM, OnExitSignal);
+	signal(SIGINT, OnExitSignal);
 
 #if SSR_USE_ALSA
 	if(m_simple_synth != NULL) {


### PR DESCRIPTION

For now ssr writes stream to file as it records, so there is no reasons to drop recorded file just because user not explicitly stated that he want to save it.

This PR actually makes it to proper save file on exit.

About code: not sure where to place signal handlers registration, but for now it works.

Original motivation of this was to use ssr just like a cli to make a system-wide binds for start/stop recording. [(example from i3 config)](https://github.com/UnkwUsr/dotfiles/blob/7bef20c2b0ace2b02bc86c295eb05ab7dff13803/config/i3/config#L263-L266)

UPD: testing it for about 1 year, works flawlessly in my use case