### PR TITLE
Better warning popup when quitting with unsaved recording

### DIFF
--- a/src/GUI/PageRecord.cpp
+++ b/src/GUI/PageRecord.cpp
@@ -431,9 +431,17 @@ PageRecord::~PageRecord() {
 
 bool PageRecord::ShouldBlockClose() {
 	if(m_output_manager != NULL) {
-		if(MessageBox(QMessageBox::Warning, this, MainWindow::WINDOW_CAPTION,
+		enum_button answer = MessageBox(QMessageBox::Warning, this, MainWindow::WINDOW_CAPTION,
 					  tr("You have not saved the current recording yet, if you quit now it will be lost.\n"
-						 "Are you sure that you want to quit?"), BUTTON_YES | BUTTON_NO, BUTTON_YES) != BUTTON_YES) {
+						 "What would you like to do with it?"), BUTTON_SAVE | BUTTON_DISCARD | BUTTON_CANCEL);
+		if(answer == BUTTON_DISCARD) {
+			return false;
+		}
+		if(answer == BUTTON_CANCEL) {
+			return true;
+		}
+		if(answer == BUTTON_SAVE) {
+			OnRecordSave();
 			return true;
 		}
 	}

--- a/src/common/Dialogs.cpp
+++ b/src/common/Dialogs.cpp
@@ -38,6 +38,8 @@ enum_button MessageBox(QMessageBox::Icon icon, QWidget* parent, const QString& t
 		{BUTTON_YES_ALWAYS, QDialogButtonBox::tr("Yes, always"), QMessageBox::YesRole   , NULL},
 		{BUTTON_NO        , QDialogButtonBox::tr("&No")        , QMessageBox::NoRole    , NULL},
 		{BUTTON_NO_NEVER  , QDialogButtonBox::tr("No, never")  , QMessageBox::NoRole    , NULL},
+		{BUTTON_DISCARD   , QDialogButtonBox::tr("Discard")    , QMessageBox::AcceptRole, NULL},
+		{BUTTON_SAVE      , QDialogButtonBox::tr("Save")       , QMessageBox::YesRole   , NULL}
 	};
 
 	// add buttons

--- a/src/common/Dialogs.h
+++ b/src/common/Dialogs.h
@@ -29,6 +29,8 @@ enum enum_button : int {
 	BUTTON_YES_ALWAYS = 0x0008,
 	BUTTON_NO         = 0x0010,
 	BUTTON_NO_NEVER   = 0x0020,
+	BUTTON_DISCARD    = 0x0040,
+	BUTTON_SAVE       = 0x0080,
 };
 
 // Shows a standard Qt dialog with translated buttons.

--- a/src/translations/simplescreenrecorder_cs.ts
+++ b/src/translations/simplescreenrecorder_cs.ts
@@ -2207,9 +2207,9 @@ Tyto klávesy budou odchyceny a nebudou předány nahrávané aplikaci.</transla
     <message>
         <location filename="../GUI/PageRecord.cpp" line="435"/>
         <source>You have not saved the current recording yet, if you quit now it will be lost.
-Are you sure that you want to quit?</source>
+What would you like to do with it?</source>
         <translation>Aktuální nahrávka dosud nebyla uložena a pokud program ukončíte nyní, bude ztracena.
-Opravdu chcete program ukončit? </translation>
+Co s ní chcete dělat?</translation>
     </message>
     <message>
         <location filename="../GUI/PageRecord.cpp" line="447"/>
@@ -2550,6 +2550,11 @@ Tlačítko Spustit nahrávání je nahoře ;).</translation>
         <location filename="../common/Dialogs.cpp" line="40"/>
         <source>No, never</source>
         <translation type="unfinished">Ne, nikdy</translation>
+    </message>
+    <message>
+        <location filename="../common/Dialogs.cpp" line="41"/>
+        <source>Discard</source>
+        <translation type="unfinished">Zahodit</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
Hi, I didn't like the Yes/No option when quitting the app from an unsaved recording. Now I think it's much more clear to understand what to press, if you forget to read the popup. I'm **not** really good in C++, so I hope I didn't break anything.

**How the popup looks now:**
![obrazek](https://user-images.githubusercontent.com/51487573/173252162-eeb0bd61-0a9f-4e2f-a0a2-9d77b85559f5.png)