### PR TITLE
Update references to AVChannelLayout for compatibility with FFmpeg 7

### DIFF
--- a/src/AV/Output/BaseEncoder.cpp
+++ b/src/AV/Output/BaseEncoder.cpp
@@ -176,7 +176,7 @@ void BaseEncoder::Init(AVCodec* codec, AVDictionary** options) {
 
 void BaseEncoder::Free() {
 	if(m_codec_opened) {
-		avcodec_close(m_codec_context);
+		avcodec_free_context(&m_codec_context);
 		m_codec_opened = false;
 	}
 }

--- a/src/AV/Output/Synchronizer.cpp
+++ b/src/AV/Output/Synchronizer.cpp
@@ -180,7 +180,7 @@ static std::unique_ptr<AVFrameWrapper> CreateAudioFrame(unsigned int channels, u
 	frame->GetFrame()->nb_samples = samples;
 #endif
 #if SSR_USE_AVFRAME_CHANNELS
-	frame->GetFrame()->channels = channels;
+	frame->GetFrame()->ch_layout.nb_channels = channels;
 #endif
 #if SSR_USE_AVFRAME_SAMPLE_RATE
 	frame->GetFrame()->sample_rate = sample_rate;


### PR DESCRIPTION
Some of the AVCodec interface has changed with FFmpeg 7. This PR updates references to AVChannelLayout properties to resolve the compile errors and replaces a call to the deprecated avcodec_close function with avcodec_free_context.