### PR TITLE
Use simde to accelerate for loongarch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,14 +9,18 @@ set(CMAKE_CXX_STANDARD 11)
 
 project(simplescreenrecorder VERSION 0.4.4)
 
+set(PROCESSOR_IS_X86 FALSE)
+set(PROCESSOR_IS_LOONGARCH FALSE)
+
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|amd64|i386|i686")
 	set(PROCESSOR_IS_X86 TRUE)
-else()
-	set(PROCESSOR_IS_X86 FALSE)
+elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "loongarch")
+	set(PROCESSOR_IS_LOONGARCH TRUE)
 endif()
 
 option(ENABLE_32BIT_GLINJECT "Build the 32-bit version of 'libssr-glinject' on 64-bit systems (in addition to the 64-bit version). Required for OpenGL recording of 32-bit applications on 64-bit systems." FALSE)
 option(ENABLE_X86_ASM "Allow x86/x64 assembly or intrinsics." ${PROCESSOR_IS_X86})
+option(ENABLE_LOONGARCH_ASM "Allow loongarch assembly or intrinsics." ${PROCESSOR_IS_LOONGARCH})
 option(ENABLE_FFMPEG_VERSIONS "Use FFmpeg version numbers for feature support tests. Enable when using FFmpeg, disable when using Libav." TRUE)
 option(ENABLE_JACK_METADATA "Use the JACK metadata API. May not work with very old JACK versions." TRUE)
 option(WITH_OPENGL_RECORDING "Build with OpenGL recording support." TRUE)
@@ -29,6 +33,7 @@ option(WITH_QT5 "Build with Qt5 (instead of Qt4)." FALSE)
 option(WITH_QT6 "Build with Qt6 (instead of Qt4/5)." FALSE)
 option(WITH_SIMPLESCREENRECORDER "Build the 'simplescreenrecorder' executable." TRUE)
 option(WITH_GLINJECT "Build the 'libssr-glinject' library. Required for OpenGL recording." TRUE)
+option(WITH_SIMDE "Build with SIMDE support." ${PROCESSOR_IS_LOONGARCH})
 
 set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 

--- a/cmake/FindSIMDE.cmake
+++ b/cmake/FindSIMDE.cmake
@@ -1,0 +1,13 @@
+# rules for finding the SIMDE library
+
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(PC_SIMDE simde)
+
+find_path(SIMDE_INCLUDE_DIR simde/x86/sse2.h simde/x86/ssse3.h HINTS ${PC_SIMDE_INCLUDEDIR} ${PC_SIMDE_INCLUDE_DIRS})
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(SIMDE DEFAULT_MSG SIMDE_INCLUDE_DIR)
+
+mark_as_advanced(SIMDE_INCLUDE_DIR)
+
+set(SIMDE_INCLUDE_DIRS ${SIMDE_INCLUDE_DIR})

--- a/src/AV/FastResampler.cpp
+++ b/src/AV/FastResampler.cpp
@@ -97,8 +97,14 @@ FastResampler::FastResampler(unsigned int channels, float gain) {
 	m_filter_rows = 0;
 
 	// CPU feature detection
+	bool use_asm = false;
 #if SSR_USE_X86_ASM
-	if(CPUFeatures::HasMMX() && CPUFeatures::HasSSE() && CPUFeatures::HasSSE2()) {
+	use_asm = CPUFeatures::HasMMX() && CPUFeatures::HasSSE() && CPUFeatures::HasSSE2();
+#elif SSR_USE_LOONGARCH_ASM
+	use_asm = CPUFeatures::HasLSX();
+#endif
+#if SSR_USE_X86_ASM || SSR_USE_LOONGARCH_ASM
+	if(use_asm) {
 		switch(m_channels) {
 			case 1:  m_firfilter2_ptr = &FastResampler_FirFilter2_C1_SSE2; break;
 			case 2:  m_firfilter2_ptr = &FastResampler_FirFilter2_C2_SSE2; break;
@@ -111,7 +117,7 @@ FastResampler::FastResampler(unsigned int channels, float gain) {
 			case 2:  m_firfilter2_ptr = &FastResampler_FirFilter2_C2_Fallback; break;
 			default: m_firfilter2_ptr = &FastResampler_FirFilter2_Cn_Fallback; break;
 		}
-#if SSR_USE_X86_ASM
+#if SSR_USE_X86_ASM || SSR_USE_LOONGARCH_ASM
 	}
 #endif
 

--- a/src/AV/FastResampler_FirFilter.h
+++ b/src/AV/FastResampler_FirFilter.h
@@ -26,7 +26,7 @@ void FastResampler_FirFilter2_C1_Fallback(unsigned int channels, unsigned int fi
 void FastResampler_FirFilter2_C2_Fallback(unsigned int channels, unsigned int filter_length, float* coef1, float* coef2, float frac, float* input, float* output);
 void FastResampler_FirFilter2_Cn_Fallback(unsigned int channels, unsigned int filter_length, float* coef1, float* coef2, float frac, float* input, float* output);
 
-#if SSR_USE_X86_ASM
+#if SSR_USE_X86_ASM || SSR_USE_LOONGARCH_ASM
 void FastResampler_FirFilter2_C1_SSE2(unsigned int channels, unsigned int filter_length, float* coef1, float* coef2, float frac, float* input, float* output);
 void FastResampler_FirFilter2_C2_SSE2(unsigned int channels, unsigned int filter_length, float* coef1, float* coef2, float frac, float* input, float* output);
 void FastResampler_FirFilter2_Cn_SSE2(unsigned int channels, unsigned int filter_length, float* coef1, float* coef2, float frac, float* input, float* output);

--- a/src/AV/FastResampler_FirFilter_SSE2.cpp
+++ b/src/AV/FastResampler_FirFilter_SSE2.cpp
@@ -19,10 +19,19 @@ along with SimpleScreenRecorder.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "FastResampler_FirFilter.h"
 
+#if SSR_USE_X86_ASM || SSR_USE_LOONGARCH_ASM
+
 #if SSR_USE_X86_ASM
 
 #include <xmmintrin.h> // sse
 #include <emmintrin.h> // sse2
+
+#else
+
+#define SIMDE_ENABLE_NATIVE_ALIASES
+#include <simde/x86/sse2.h>
+
+#endif
 
 void FastResampler_FirFilter2_C1_SSE2(unsigned int channels, unsigned int filter_length, float* coef1, float* coef2, float frac, float* input, float* output) {
 	Q_UNUSED(channels);

--- a/src/AV/FastScaler.cpp
+++ b/src/AV/FastScaler.cpp
@@ -31,8 +31,13 @@ FastScaler::FastScaler() {
 
 #if SSR_USE_X86_ASM
 	m_warn_alignment = true;
+	m_use_asm = CPUFeatures::HasMMX() && CPUFeatures::HasSSE() && CPUFeatures::HasSSE2() && CPUFeatures::HasSSE3() && CPUFeatures::HasSSSE3();
 #endif
 
+#if SSR_USE_LOONGARCH_ASM
+	m_warn_alignment = true;
+	m_use_asm = CPUFeatures::HasLSX();
+#endif
 	m_warn_swscale = true;
 	m_sws_context = NULL;
 
@@ -148,8 +153,8 @@ void FastScaler::Scale(unsigned int in_width, unsigned int in_height, AVPixelFor
 
 void FastScaler::Convert_BGRA_YUV444(unsigned int width, unsigned int height, const uint8_t* in_data, int in_stride, uint8_t* const out_data[3], const int out_stride[3]) {
 
-#if SSR_USE_X86_ASM
-	if(CPUFeatures::HasMMX() && CPUFeatures::HasSSE() && CPUFeatures::HasSSE2() && CPUFeatures::HasSSE3() && CPUFeatures::HasSSSE3()) {
+#if SSR_USE_X86_ASM || SSR_USE_LOONGARCH_ASM
+	if(m_use_asm) {
 		if((uintptr_t) out_data[0] % 16 == 0 && out_stride[0] % 16 == 0 &&
 		   (uintptr_t) out_data[1] % 16 == 0 && out_stride[1] % 16 == 0 &&
 		   (uintptr_t) out_data[2] % 16 == 0 && out_stride[2] % 16 == 0) {
@@ -173,8 +178,8 @@ void FastScaler::Convert_BGRA_YUV444(unsigned int width, unsigned int height, co
 void FastScaler::Convert_BGRA_YUV422(unsigned int width, unsigned int height, const uint8_t* in_data, int in_stride, uint8_t* const out_data[3], const int out_stride[3]) {
 	assert(width % 2 == 0);
 
-#if SSR_USE_X86_ASM
-	if(CPUFeatures::HasMMX() && CPUFeatures::HasSSE() && CPUFeatures::HasSSE2() && CPUFeatures::HasSSE3() && CPUFeatures::HasSSSE3()) {
+#if SSR_USE_X86_ASM || SSR_USE_LOONGARCH_ASM
+	if(m_use_asm) {
 		if((uintptr_t) out_data[0] % 16 == 0 && out_stride[0] % 16 == 0 &&
 		   (uintptr_t) out_data[1] % 16 == 0 && out_stride[1] % 16 == 0 &&
 		   (uintptr_t) out_data[2] % 16 == 0 && out_stride[2] % 16 == 0) {
@@ -198,8 +203,8 @@ void FastScaler::Convert_BGRA_YUV422(unsigned int width, unsigned int height, co
 void FastScaler::Convert_BGRA_YUV420(unsigned int width, unsigned int height, const uint8_t* in_data, int in_stride, uint8_t* const out_data[3], const int out_stride[3]) {
 	assert(width % 2 == 0 && height % 2 == 0);
 
-#if SSR_USE_X86_ASM
-	if(CPUFeatures::HasMMX() && CPUFeatures::HasSSE() && CPUFeatures::HasSSE2() && CPUFeatures::HasSSE3() && CPUFeatures::HasSSSE3()) {
+#if SSR_USE_X86_ASM || SSR_USE_LOONGARCH_ASM
+	if(m_use_asm) {
 		if((uintptr_t) out_data[0] % 16 == 0 && out_stride[0] % 16 == 0 &&
 		   (uintptr_t) out_data[1] % 16 == 0 && out_stride[1] % 16 == 0 &&
 		   (uintptr_t) out_data[2] % 16 == 0 && out_stride[2] % 16 == 0) {
@@ -223,8 +228,8 @@ void FastScaler::Convert_BGRA_YUV420(unsigned int width, unsigned int height, co
 void FastScaler::Convert_BGRA_NV12(unsigned int width, unsigned int height, const uint8_t* in_data, int in_stride, uint8_t* const out_data[2], const int out_stride[2]) {
 	assert(width % 2 == 0 && height % 2 == 0);
 
-#if SSR_USE_X86_ASM
-	if(CPUFeatures::HasMMX() && CPUFeatures::HasSSE() && CPUFeatures::HasSSE2() && CPUFeatures::HasSSE3() && CPUFeatures::HasSSSE3()) {
+#if SSR_USE_X86_ASM || SSR_USE_LOONGARCH_ASM
+	if(m_use_asm) {
 		if((uintptr_t) out_data[0] % 16 == 0 && out_stride[0] % 16 == 0 &&
 		   (uintptr_t) out_data[1] % 16 == 0 && out_stride[1] % 16 == 0) {
 			Convert_BGRA_NV12_SSSE3(width, height, in_data, in_stride, out_data, out_stride);
@@ -246,8 +251,8 @@ void FastScaler::Convert_BGRA_NV12(unsigned int width, unsigned int height, cons
 
 void FastScaler::Convert_BGRA_BGR(unsigned int width, unsigned int height, const uint8_t* in_data, int in_stride, uint8_t* out_data, int out_stride) {
 
-#if SSR_USE_X86_ASM
-	if(CPUFeatures::HasMMX() && CPUFeatures::HasSSE() && CPUFeatures::HasSSE2() && CPUFeatures::HasSSE3() && CPUFeatures::HasSSSE3()) {
+#if SSR_USE_X86_ASM || SSR_USE_LOONGARCH_ASM
+	if(m_use_asm) {
 		if((uintptr_t) out_data % 16 == 0 && out_stride % 16 == 0) {
 			Convert_BGRA_BGR_SSSE3(width, height, in_data, in_stride, out_data, out_stride);
 		} else {
@@ -269,8 +274,8 @@ void FastScaler::Convert_BGRA_BGR(unsigned int width, unsigned int height, const
 void FastScaler::Scale_BGRA(unsigned int in_width, unsigned int in_height, const uint8_t* in_data, int in_stride,
 							unsigned int out_width, unsigned int out_height, uint8_t* out_data, int out_stride) {
 
-#if SSR_USE_X86_ASM
-	if(CPUFeatures::HasMMX() && CPUFeatures::HasSSE() && CPUFeatures::HasSSE2() && CPUFeatures::HasSSE3() && CPUFeatures::HasSSSE3()) {
+#if SSR_USE_X86_ASM || SSR_USE_LOONGARCH_ASM
+	if(m_use_asm) {
 		if((uintptr_t) out_data % 16 == 0 && out_stride % 16 == 0) {
 			Scale_BGRA_SSSE3(in_width, in_height, in_data, in_stride, out_width, out_height, out_data, out_stride);
 		} else {

--- a/src/AV/FastScaler.h
+++ b/src/AV/FastScaler.h
@@ -25,11 +25,12 @@ along with SimpleScreenRecorder.  If not, see <http://www.gnu.org/licenses/>.
 class FastScaler {
 
 private:
-#if SSR_USE_X86_ASM
+#if SSR_USE_X86_ASM || SSR_USE_LOONGARCH_ASM
 	bool m_warn_alignment;
 #endif
 
 	bool m_warn_swscale;
+	bool m_use_asm;
 	SwsContext *m_sws_context;
 
 public:

--- a/src/AV/FastScaler_Convert.h
+++ b/src/AV/FastScaler_Convert.h
@@ -26,7 +26,7 @@ void Convert_BGRA_YUV420_Fallback(unsigned int w, unsigned int h, const uint8_t*
 void Convert_BGRA_NV12_Fallback(unsigned int w, unsigned int h, const uint8_t* in_data, int in_stride, uint8_t* const out_data[2], const int out_stride[2]);
 void Convert_BGRA_BGR_Fallback(unsigned int w, unsigned int h, const uint8_t* in_data, int in_stride, uint8_t* out_data, int out_stride);
 
-#if SSR_USE_X86_ASM
+#if SSR_USE_X86_ASM || SSR_USE_LOONGARCH_ASM
 void Convert_BGRA_YUV444_SSSE3(unsigned int w, unsigned int h, const uint8_t* in_data, int in_stride, uint8_t* const out_data[3], const int out_stride[3]);
 void Convert_BGRA_YUV422_SSSE3(unsigned int w, unsigned int h, const uint8_t* in_data, int in_stride, uint8_t* const out_data[3], const int out_stride[3]);
 void Convert_BGRA_YUV420_SSSE3(unsigned int w, unsigned int h, const uint8_t* in_data, int in_stride, uint8_t* const out_data[3], const int out_stride[3]);

--- a/src/AV/FastScaler_Convert_SSSE3.cpp
+++ b/src/AV/FastScaler_Convert_SSSE3.cpp
@@ -19,12 +19,21 @@ along with SimpleScreenRecorder.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "FastScaler_Convert.h"
 
+#if SSR_USE_X86_ASM || SSR_USE_LOONGARCH_ASM
+
 #if SSR_USE_X86_ASM
 
 #include <xmmintrin.h> // sse
 #include <emmintrin.h> // sse2
 #include <pmmintrin.h> // sse3
 #include <tmmintrin.h> // ssse3
+
+#else
+
+#define SIMDE_ENABLE_NATIVE_ALIASES
+#include <simde/x86/ssse3.h>
+
+#endif
 
 /*
 ==== SSSE3 BGRA-to-YUV444/YUV420 Converter ====

--- a/src/AV/FastScaler_Scale.h
+++ b/src/AV/FastScaler_Scale.h
@@ -23,7 +23,7 @@ along with SimpleScreenRecorder.  If not, see <http://www.gnu.org/licenses/>.
 void Scale_BGRA_Fallback(unsigned int in_w, unsigned int in_h, const uint8_t* in_data, int in_stride,
 						 unsigned int out_w, unsigned int out_h, uint8_t* out_data, int out_stride);
 
-#if SSR_USE_X86_ASM
+#if SSR_USE_X86_ASM || SSR_USE_LOONGARCH_ASM
 void Scale_BGRA_SSSE3(unsigned int in_w, unsigned int in_h, const uint8_t* in_data, int in_stride,
 					  unsigned int out_w, unsigned int out_h, uint8_t* out_data, int out_stride);
 #endif

--- a/src/AV/FastScaler_Scale_SSSE3.cpp
+++ b/src/AV/FastScaler_Scale_SSSE3.cpp
@@ -22,12 +22,21 @@ along with SimpleScreenRecorder.  If not, see <http://www.gnu.org/licenses/>.
 #include "FastScaler_Scale_Generic.h"
 #include "TempBuffer.h"
 
+#if SSR_USE_X86_ASM || SSR_USE_LOONGARCH_ASM
+
 #if SSR_USE_X86_ASM
 
 #include <xmmintrin.h> // sse
 #include <emmintrin.h> // sse2
 #include <pmmintrin.h> // sse3
 #include <tmmintrin.h> // ssse3
+
+#else
+
+#define SIMDE_ENABLE_NATIVE_ALIASES
+#include <simde/x86/ssse3.h>
+
+#endif
 
 /*
 ==== SSSE3 MipMapper ====

--- a/src/Benchmark.cpp
+++ b/src/Benchmark.cpp
@@ -100,6 +100,9 @@ void BenchmarkScale(unsigned int in_w, unsigned int in_h, unsigned int out_w, un
 	bool use_ssse3 = (CPUFeatures::HasMMX() && CPUFeatures::HasSSE() && CPUFeatures::HasSSE2() && CPUFeatures::HasSSE3() && CPUFeatures::HasSSSE3());
 #endif
 
+#if SSR_USE_LOONGARCH_ASM
+	bool use_ssse3 = CPUFeatures::HasLSX();
+#endif
 	// the queue needs to use enough memory to make sure that the CPU cache is flushed
 	unsigned int pixels = std::max(in_w * in_h, out_w * out_h);
 	unsigned int queue_size = 1 + 20000000 / pixels;
@@ -146,7 +149,7 @@ void BenchmarkScale(unsigned int in_w, unsigned int in_h, unsigned int out_w, un
 		int64_t t2 = hrt_time_micro();
 		time_fallback = (t2 - t1) / run_size;
 	}
-#if SSR_USE_X86_ASM
+#if SSR_USE_X86_ASM || SSR_USE_LOONGARCH_ASM
 	if(use_ssse3) {
 		int64_t t1 = hrt_time_micro();
 		for(unsigned int i = 0; i < run_size; ++i) {
@@ -171,7 +174,7 @@ void BenchmarkScale(unsigned int in_w, unsigned int in_h, unsigned int out_w, un
 }
 
 void BenchmarkConvert(unsigned int w, unsigned int h, AVPixelFormat in_format, AVPixelFormat out_format, const QString& in_format_name, const QString& out_format_name, NewImageFunc in_image, NewImageFunc out_image, ConvertFunc fallback
-#if SSR_USE_X86_ASM
+#if SSR_USE_X86_ASM || SSR_USE_LOONGARCH_ASM
 , ConvertFunc ssse3
 #endif
 ) {
@@ -181,6 +184,9 @@ void BenchmarkConvert(unsigned int w, unsigned int h, AVPixelFormat in_format, A
 	bool use_ssse3 = (CPUFeatures::HasMMX() && CPUFeatures::HasSSE() && CPUFeatures::HasSSE2() && CPUFeatures::HasSSE3() && CPUFeatures::HasSSSE3());
 #endif
 
+#if SSR_USE_LOONGARCH_ASM
+	bool use_ssse3 = CPUFeatures::HasLSX();
+#endif
 	// the queue needs to use enough memory to make sure that the CPU cache is flushed
 	unsigned int pixels = w * h;
 	unsigned int queue_size = 1 + 20000000 / pixels;
@@ -226,7 +232,7 @@ void BenchmarkConvert(unsigned int w, unsigned int h, AVPixelFormat in_format, A
 		int64_t t2 = hrt_time_micro();
 		time_fallback = (t2 - t1) / run_size;
 	}
-#if SSR_USE_X86_ASM
+#if SSR_USE_X86_ASM || SSR_USE_LOONGARCH_ASM
 	if(use_ssse3) {
 		int64_t t1 = hrt_time_micro();
 		for(unsigned int i = 0; i < run_size; ++i) {
@@ -258,7 +264,7 @@ void Benchmark() {
 	BenchmarkScale(1920, 1080, 640, 360); // mipmap + downscaling
 
 	Logger::LogInfo("[Benchmark] " + Logger::tr("Starting converter benchmark ..."));
-#if SSR_USE_X86_ASM
+#if SSR_USE_X86_ASM || SSR_USE_LOONGARCH_ASM
 	BenchmarkConvert(1920, 1080, AV_PIX_FMT_BGRA, AV_PIX_FMT_YUV444P, "BGRA", "YUV444", NewImageBGRA, NewImageYUV444, Convert_BGRA_YUV444_Fallback           , Convert_BGRA_YUV444_SSSE3           );
 	BenchmarkConvert(1920, 1080, AV_PIX_FMT_BGRA, AV_PIX_FMT_YUV422P, "BGRA", "YUV422", NewImageBGRA, NewImageYUV422, Convert_BGRA_YUV422_Fallback           , Convert_BGRA_YUV422_SSSE3           );
 	BenchmarkConvert(1920, 1080, AV_PIX_FMT_BGRA, AV_PIX_FMT_YUV420P, "BGRA", "YUV420", NewImageBGRA, NewImageYUV420, Convert_BGRA_YUV420_Fallback           , Convert_BGRA_YUV420_SSSE3           );

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -34,6 +34,10 @@ else()
 	find_package(Qt4 4.8 COMPONENTS QtGui REQUIRED)
 endif()
 
+if(WITH_SIMDE)
+	find_package(SIMDE REQUIRED)
+endif()
+
 set(sources
 	AV/Input/ALSAInput.cpp
 	AV/Input/ALSAInput.h
@@ -164,6 +168,21 @@ if(ENABLE_X86_ASM)
 		PROPERTIES COMPILE_FLAGS -mssse3
 	)
 
+elseif(ENABLE_LOONGARCH_ASM)
+
+	list(APPEND sources
+		AV/FastResampler_FirFilter_SSE2.cpp
+		AV/FastScaler_Convert_SSSE3.cpp
+		AV/FastScaler_Scale_SSSE3.cpp
+	)
+
+	set_source_files_properties(
+		AV/FastResampler_FirFilter_SSE2.cpp
+		AV/FastScaler_Convert_SSSE3.cpp
+		AV/FastScaler_Scale_SSSE3.cpp
+		PROPERTIES COMPILE_FLAGS -mlsx
+	)
+
 endif()
 
 set(res_input
@@ -215,6 +234,7 @@ target_include_directories(simplescreenrecorder PRIVATE
 	$<$<BOOL:${WITH_ALSA}>:${ALSA_INCLUDE_DIRS}>
 	$<$<BOOL:${WITH_PULSEAUDIO}>:${PULSEAUDIO_INCLUDE_DIRS}>
 	$<$<BOOL:${WITH_JACK}>:${JACK_INCLUDE_DIRS}>
+	$<$<BOOL:${WITH_SIMDE}>:${SIMDE_INCLUDE_DIRS}>
 	${CMAKE_CURRENT_SOURCE_DIR}
 	${CMAKE_CURRENT_SOURCE_DIR}/AV
 	${CMAKE_CURRENT_SOURCE_DIR}/AV/Input
@@ -244,6 +264,7 @@ target_link_libraries(simplescreenrecorder PRIVATE
 
 target_compile_definitions(simplescreenrecorder PRIVATE
 	-DSSR_USE_X86_ASM=$<BOOL:${ENABLE_X86_ASM}>
+	-DSSR_USE_LOONGARCH_ASM=$<BOOL:${ENABLE_LOONGARCH_ASM}>
 	-DSSR_USE_FFMPEG_VERSIONS=$<BOOL:${ENABLE_FFMPEG_VERSIONS}>
 	-DSSR_USE_JACK_METADATA=$<BOOL:${ENABLE_JACK_METADATA}>
 	-DSSR_USE_OPENGL_RECORDING=$<BOOL:${WITH_OPENGL_RECORDING}>

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -105,7 +105,7 @@ int main(int argc, char* argv[]) {
 	Logger::LogInfo("==================== " + Logger::tr("SSR started") + " ====================");
 	Logger::LogInfo(GetVersionInfo());
 
-#if SSR_USE_X86_ASM
+#if SSR_USE_X86_ASM || SSR_USE_LOONGARCH_ASM
 	// detect CPU features
 	CPUFeatures::Detect();
 #endif

--- a/src/common/CPUFeatures.cpp
+++ b/src/common/CPUFeatures.cpp
@@ -74,3 +74,28 @@ void CPUFeatures::Detect() {
 }
 
 #endif // SSR_USE_X86_ASM
+
+#if SSR_USE_LOONGARCH_ASM
+
+#include <sys/auxv.h>
+
+#define LA_HWCAP_LSX    (1<<4)
+#define LA_HWCAP_LASX   (1<<5)
+
+bool CPUFeatures::s_lsx  = false;
+bool CPUFeatures::s_lasx = false;
+
+void CPUFeatures::Detect() {
+
+	QString str = "[CPUFeatures::Detect] " + Logger::tr("CPU features") + ":";
+
+	int flags = 0;
+	int flag  = (int)getauxval(AT_HWCAP);
+
+	if (flag & LA_HWCAP_LSX)  {s_lsx  = true; str += " lsx";}
+	if (flag & LA_HWCAP_LASX) {s_lasx = true; str += " lasx";}
+
+	Logger::LogInfo(str);
+}
+
+#endif // SSR_USE_LOONGARCH_ASM

--- a/src/common/CPUFeatures.h
+++ b/src/common/CPUFeatures.h
@@ -48,3 +48,20 @@ public:
 };
 
 #endif // SSR_USE_X86_ASM
+
+#if SSR_USE_LOONGARCH_ASM
+
+class CPUFeatures {
+
+private:
+	static bool s_lsx, s_lasx;
+
+public:
+	static void Detect();
+
+	inline static bool HasLSX()  { return s_lsx; }
+	inline static bool HasLASX() { return s_lasx; }
+
+};
+
+#endif // SSR_USE_LOONGARCH_ASM


### PR DESCRIPTION
We have integrated simde into AV subdirectory and removed unused files, which does not need system-dependent simde header files. We have tested locally on X86 and LoongArch platform, it seems everything is fine. Reviews are welcome. Thanks.