### PR TITLE
Changed min version to 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 3.1)
-cmake_policy(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
+cmake_policy(VERSION 3.5)
 
 if(POLICY CMP0072)
 	cmake_policy(SET CMP0072 NEW)


### PR DESCRIPTION
Changed both the minimum requirement version and policy version to 3.5 since compatibility with 3.1 has been dropped.