### PR TITLE
For #1074: newer ffmpeg versions need destructor implementation for m…

### DIFF
--- a/src/AV/Output/BaseEncoder.cpp
+++ b/src/AV/Output/BaseEncoder.cpp
@@ -178,6 +178,8 @@ void BaseEncoder::Free() {
 	if(m_codec_opened) {
 #if !SSR_USE_AVCODEC_CLOSE_DEPRECATED
 		avcodec_close(m_codec_context);
+#else
+		avcodec_free_context(&m_codec_context);
 #endif
 		m_codec_opened = false;
 	}


### PR DESCRIPTION
…emory cleanup.

This seems to solve the memory leak on OpenSUSE tumbleweed/slowroll ffmpeg.