### PR TITLE
Fix Qt<6.5 timezone operations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 3.5)
-cmake_policy(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
+cmake_policy(VERSION 3.10)
 
 if(POLICY CMP0072)
 	cmake_policy(SET CMP0072 NEW)

--- a/src/GUI/DialogRecordSchedule.cpp
+++ b/src/GUI/DialogRecordSchedule.cpp
@@ -33,8 +33,8 @@ ENUMSTRINGS(enum_schedule_action) = {
 
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 const QTimeZone SCHEDULE_TIME_ZONE_QTIMEZONES[SCHEDULE_TIME_ZONE_COUNT] = {
-	QTimeZone::LocalTime,
-	QTimeZone::UTC,
+	QTimeZone::systemTimeZone(),
+	QTimeZone::utc(),
 };
 #else
 const Qt::TimeSpec SCHEDULE_TIME_ZONE_QTIMESPECS[SCHEDULE_TIME_ZONE_COUNT] = {

--- a/src/GUI/DialogRecordSchedule.h
+++ b/src/GUI/DialogRecordSchedule.h
@@ -64,9 +64,9 @@ public:
 	~RecordScheduleEntryWidget();
 
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-	inline void Print(const QString& str) { qDebug() << "timezone" << str << m_datetimeedit_time->dateTime() << m_datetimeedit_time->timeZone(); }
-	inline void SetTimeZone(QTimeZone spec) { m_datetimeedit_time->setTimeZone(spec); m_datetimeedit_time->setDateTime(m_datetimeedit_time->dateTime()); }
-	inline void SetTime(const QDateTime& time) { m_datetimeedit_time->setTimeZone(time.timeZone()); m_datetimeedit_time->setDateTime(time); }
+	inline void Print(const QString& str) { qDebug() << "timezone" << str << m_datetimeedit_time->dateTime() << m_datetimeedit_time->dateTime().timeZone(); }
+	inline void SetTimeZone(const QTimeZone& zone) { QDateTime dt = m_datetimeedit_time->dateTime(); dt.setTimeZone(zone); m_datetimeedit_time->setDateTime(dt); }
+	inline void SetTime(const QDateTime& time) { m_datetimeedit_time->setDateTime(time); }
 #else
 	inline void Print(const QString& str) { qDebug() << "timespec" << str << m_datetimeedit_time->dateTime() << m_datetimeedit_time->timeSpec(); }
 	inline void SetTimeSpec(Qt::TimeSpec spec) { m_datetimeedit_time->setTimeSpec(spec); m_datetimeedit_time->setDateTime(m_datetimeedit_time->dateTime()); }


### PR DESCRIPTION
Hello,

This is a quick fix that prevent building on Qt < 6.5 because QTimeZone enums and methods are recent.
See https://doc.qt.io/qt-6/qtimezone.html#public-types
Note that currently, Ubuntu jammy & noble only have Qt 6.2.4 and 6.4.2 respectively.

I also bumped the minimum CMake version to 3.10 that the latest CMake version recommends :)